### PR TITLE
Create set_governor

### DIFF
--- a/Scripts/set_governor
+++ b/Scripts/set_governor
@@ -1,0 +1,11 @@
+#!/bin/bash
+#使用脚本需安装CPU频率设置工具： apt install cpufrequtils
+#最大评率可以设置为0.7-3.8
+#cpu调节器可以设置‘powersave’或‘performance’
+  
+maxfreq='3.8GHz'
+gov='powersave'
+
+for ((i=0;i<$(nproc);i++)); do
+    cpufreq-set -g $gov -u $maxfreq -c$i 
+done


### PR DESCRIPTION
有关PVE下cpu调度，目前pve（debian）采用intel p-state 驱动的调度只有powersave和performance两种，默认performance，其中powersave模式和传统acpi驱动的powersave不同，大致等于acpi驱动下的ondemand，所以要想R2 PVE 温度不那么高，可以使用cpufreq-set工具设置为 powersave 模式。通过自测，这个模式并不会降低性能，负载升高时也能运行在高频下。优势是负载低的时候较节能，温度较低。
Intel 官方说明：
They are not generic scaling governors, but their names are the same as the names of some of those governors. Moreover, confusingly enough, they generally do not work in the same way as the generic governors they share the names with. For example, the powersave P-state selection algorithm provided by intel_pstate is not a counterpart of the generic powersave governor (roughly, it corresponds to the schedutil and ondemand governors).